### PR TITLE
Sysdig version and SHA pinning

### DIFF
--- a/start/action.yaml
+++ b/start/action.yaml
@@ -15,6 +15,11 @@ inputs:
     type: string
     required: false
     default: 'latest'
+  sysdig-version: 
+    description: 'Sysdig version to use'
+    type: string
+    required: false
+    default: 'latest'
   config-file:
     description: 'Start action with a config file. Only used in analyze mode'
     type: string
@@ -65,6 +70,14 @@ runs:
         MOUNT_CICD_DEFAULT_RULES="-v ${{github.action_path}}/rules/falco_cicd_rules.yaml:/etc/falco/rules.d/cicd_rules.yaml"
       fi
 
+      IMAGE="falcosecurity/falco-no-driver"
+      # If the version string starts with "sha256:", use @digest syntax
+      if [[ "$FALCO_VERSION" =~ ^sha256: ]]; then
+        FULL_IMAGE="${IMAGE}@${FALCO_VERSION}"
+      else
+        FULL_IMAGE="${IMAGE}:${FALCO_VERSION}"
+      fi
+
       docker run --rm -d \
         --name falco \
         --privileged \
@@ -74,7 +87,7 @@ runs:
         -v /etc:/host/etc:ro \
         $MOUNT_CUSTOM_RULE \
         $MOUNT_CICD_DEFAULT_RULES \
-        falcosecurity/falco-no-driver:$FALCO_VERSION falco -o "json_output=true" -o "file_output.enabled=true" -o "file_output.keep_alive=false" -o "file_output.filename=/tmp/falco_events.json" -o "engine.kind=modern_ebpf"
+        "$FULL_IMAGE" falco -o "json_output=true" -o "file_output.enabled=true" -o "file_output.keep_alive=false" -o "file_output.filename=/tmp/falco_events.json" -o "engine.kind=modern_ebpf"
 
       # Wait for the Falco container to be fully started
       for i in {1..30}; do
@@ -96,6 +109,7 @@ runs:
     env:
       VERBOSE: ${{ inputs.verbose }}
       CONFIG_FILE: ${{ inputs.config-file }}
+      SYSDIG_VERSION: ${{ inputs.sysdig-version }}
     shell: bash
     run: |
       if [[ "$VERBOSE" == "true" ]]; then
@@ -129,6 +143,14 @@ runs:
         echo $IGNORE_SYSCALLS_FILTER
       fi
 
+        IMAGE="sysdig/sysdig"
+        # If the version string starts with "sha256:", use @digest syntax
+        if [[ "$SYSDIG_VERSION" =~ ^sha256: ]]; then
+          FULL_IMAGE="${IMAGE}@${SYSDIG_VERSION}"
+        else
+          FULL_IMAGE="${IMAGE}:${SYSDIG_VERSION}"
+        fi
+
       echo "Creating Sysdig container"
       docker run --rm -d --name sysdig --privileged \
         -v /var/run/docker.sock:/host/var/run/docker.sock \
@@ -137,7 +159,7 @@ runs:
         -v /lib/modules:/host/lib/modules:ro \
         -v /usr:/host/usr:ro \
         -v /tmp:/tmp \
-        --net=host sysdig/sysdig:latest sysdig --modern-bpf -w /tmp/capture.scap --snaplen=256 "not evt.type in (switch) $IGNORE_SYSCALLS_FILTER"
+        --net=host "$FULL_IMAGE" sysdig --modern-bpf -w /tmp/capture.scap --snaplen=256 "not evt.type in (switch) $IGNORE_SYSCALLS_FILTER"
       echo "Sysdig started"
 
       # Ensure Sysdig container is running


### PR DESCRIPTION
I noticed you can specify a version of the falco container, but not the sysdig container.

This PR adds a sysdig-version variable to the action.

It also adds support for SHA pinning the versions, tags still work.

Specifying no version defaults to latest.

what implementation looks like 

```
    - name: Start Sysdig System Capture
      uses: KingBain/falco-actions/start@container-versions
      with:
        mode: analyze
        #sysdig-version: "sha256:c63ec30ce5db5b0d934343028031bba32b81cb7cb3f82e82d87b72c9b1694922"
        #sysdig-version: 0.40.1
```

both work
